### PR TITLE
fix(versions): update sonatype/nexus3 to 3.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonatype/nexus3:3.8.0
+FROM sonatype/nexus3:3.13.0
 
 COPY *.json /opt/sonatype/nexus/
 COPY repositories /opt/sonatype/nexus/repositories


### PR DESCRIPTION
So, that it will be possible to extend jenkinsxio/nexus image with addon to enable support for Nexus Blobstore for Google Cloud Storage on GCP -> https://github.com/igdianov/nexus-blobstore-google-cloud