### PR TITLE
Add some useful repositories

### DIFF
--- a/maven-group.json
+++ b/maven-group.json
@@ -1,5 +1,5 @@
 {
     "name": "maven-group",
     "type": "groovy",
-    "content": "def name='maven-group'\ndef members = ['maven-public','maven-central', 'maven-releases', 'maven-snapshots', 'spring-milestone', 'spring-release', 'jitpack', 'jenkins-release', 'maven-jenkinsci', 'jenkins-public']\nif(!repository.getRepositoryManager().exists(name)) { repository.createMavenGroup(name, members) }"
+    "content": "def name='maven-group'\ndef members = ['maven-public','maven-central', 'maven-releases', 'maven-snapshots', 'spring-milestone', 'spring-release', 'jitpack', 'jenkins-release', 'maven-jenkinsci', 'jenkins-public', 'plugins-gradle']\nif(!repository.getRepositoryManager().exists(name)) { repository.createMavenGroup(name, members) }"
 }

--- a/repositories/gradle-distributions.json
+++ b/repositories/gradle-distributions.json
@@ -1,0 +1,5 @@
+{
+  "name": "gradle-distributions",
+  "type": "groovy",
+  "content": "def name='gradle-distributions'\ndef url='https://services.gradle.org/distributions/'\nif(!repository.getRepositoryManager().exists(name)) { repository.createRawProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
+}

--- a/repositories/jenkins-public.json
+++ b/repositories/jenkins-public.json
@@ -1,5 +1,5 @@
 {
   "name": "jenkins-public",
   "type": "groovy",
-  "content": "def name='jenkins-public'\ndef url='https://repo.jenkins-ci.org/public/'\nif(!repository.getRepositoryManager().exists('jenkins-public')) { repository.createMavenProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
+  "content": "def name='jenkins-public'\ndef url='https://repo.jenkins-ci.org/public/'\nif(!repository.getRepositoryManager().exists(name)) { repository.createMavenProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
 }

--- a/repositories/npmjs-registry.json
+++ b/repositories/npmjs-registry.json
@@ -1,0 +1,5 @@
+{
+  "name": "npmjs-registry",
+  "type": "groovy",
+  "content": "def name='npmjs-registry'\ndef url='https://registry.npmjs.org'\nif(!repository.getRepositoryManager().exists(name)) { repository.createNpmProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
+}

--- a/repositories/plugins-gradle.json
+++ b/repositories/plugins-gradle.json
@@ -1,0 +1,5 @@
+{
+  "name": "plugins-gradle",
+  "type": "groovy",
+  "content": "def name='plugins-gradle'\ndef url='https://plugins.gradle.org/m2'\nif(!repository.getRepositoryManager().exists(name)) { repository.createMavenProxy(name, url) }\nrepository.getRepositoryManager().get(name).getConfiguration().getAttributes().'proxy'.'contentMaxAge' = -1"
+}


### PR DESCRIPTION
Having the gradle-distributions in there means a developer can still use the gradle wrapper by replacing the distributionUrl, e.g.
```
                echo "Set replacements to use internal nexus."
                sh """sed -i.nexus-replacements \
                        -e 's|https|http|g' \
                        -e 's|services.gradle.org/distributions|nexus/repository/gradle-distributions|g' \
                        gradle/wrapper/gradle-wrapper.properties"""
```

The npmjs-registry is useful for nodejs projects. Again, replacements are needed, or by setting it in the command line á la
```
$ npm config ls -l --"registry=http://nexus/repository/npmjs-registry" --"always-auth=false" | grep -E "registry = |auth = "
always-auth = false
metrics-registry = "http://localhost:8081/repository/bla"
registry = "http://localhost:8081/repository/bla"
; registry = "https://registry.npmjs.org/" (overridden)
always-auth = false
; metrics-registry = null (overridden)
; registry = "https://registry.npmjs.org/" (overridden)
```

The repository for the gradle plugins can be utilised in the `settings.gradle` by doing something like (*note*: the snippet below is using kotlin dsl)
```
val isCiServer = System.getenv().containsKey("CI")

if (isCiServer) {
    pluginManagement {
        repositories {
            maven {
                setUrl("http://nexus/repository/plugins-gradle")
            }
            maven {
                setUrl("https://plugins.gradle.org/m2/")
            }
        }
    }
} else {
    pluginManagement {
        repositories {
...
...
```