### PR TITLE
Adding resource requests and limits to deployment

### DIFF
--- a/charts/nexus/values.yaml
+++ b/charts/nexus/values.yaml
@@ -14,12 +14,12 @@ service:
   annotations:
     fabric8.io/expose: "true"
 resources:
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+  limits:
+    cpu: 100m
+    memory: 4Gi
+  requests:
+    cpu: 100m
+    memory: 4GMi
 readinessProbe:
   initialDelaySeconds: 30
   periodSeconds: 30

--- a/charts/nexus/values.yaml
+++ b/charts/nexus/values.yaml
@@ -19,7 +19,7 @@ resources:
     memory: 4Gi
   requests:
     cpu: 100m
-    memory: 4GMi
+    memory: 4Gi
 readinessProbe:
   initialDelaySeconds: 30
   periodSeconds: 30


### PR DESCRIPTION
According to https://help.sonatype.com/repomanager3/system-requirements#SystemRequirements-InstanceSizingProfiles 4GB is the recommended minimum RAM for a small installation of Nexus Repomanager 3. It is also for that size of RAM the image is tuned by default https://hub.docker.com/r/sonatype/nexus3#notes

When setting the request to the same as the limit I'm taking into account that lucene utilises not only userland memory, but also OS buffers.

Fixes #18