### PR TITLE
fix: do not define the limits for resources

### DIFF
--- a/charts/nexus/values.yaml
+++ b/charts/nexus/values.yaml
@@ -14,12 +14,12 @@ service:
   annotations:
     fabric8.io/expose: "true"
 resources:
-  limits:
-    cpu: 100m
-    memory: 4Gi
-  requests:
-    cpu: 100m
-    memory: 4Gi
+  # limits:
+    # cpu: 100m
+    # memory: 4Gi
+  # requests:
+    # cpu: 100m
+    # memory: 4Gi
 readinessProbe:
   initialDelaySeconds: 30
   periodSeconds: 30


### PR DESCRIPTION
The current resources limit will hang the entire platform installation fro low resources nodes such as n1-standard-2 on GKE.

fixes #29 